### PR TITLE
build: use deploy key to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: 'develop'
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
-      - name: Branch change and package version update
+      - name: Configure git
         run: |
           git config --local user.email "github-actions@github.com"
           git config --local user.name "GitHub Actions"
-          git checkout develop
+
+      - name: Package version update
+        run: |
           npm version --no-git-tag-version --no-commit-hooks ${{ inputs.next_version }}
 
       - name: Modify algoliaconfig file


### PR DESCRIPTION
GitHub introduced [rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) last year, a new way to protect branches.

More recently, rulesets now permit to add a `Deploy key` to the bypass list ([doc](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/creating-rulesets-for-a-repository#granting-bypass-permissions-for-your-branch-or-tag-ruleset)).

This permits to store the private SSH key of the Deploy key in a [secret](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions), and checkout the repository using this key.
After that, the Action can now push on protected branches.

## Changes

- Make the Action checkout the repo using the `DEPLOY_KEY` secret.

I've already done the following on the repo:
- Created a [deploy key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys) with write permissions
- Saved the private SSH key in a `DEPLOY_KEY` secret
- Replaced the legacy branch protections by some rulesets, with `Deploy keys` added to the bypass list. You can view them [here](https://github.com/algolia/algolia-pwa-demo/settings/rules).

## Test

At next release.
I've also tested it on a test repo: https://github.com/sbellone/release-workflow-example


---
SFCC-384